### PR TITLE
Feature/slack channel names

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,10 +28,11 @@ module.exports = function (grunt) {
       tasks: ['test']
     },
     coffeelint: {
-      app: ['src/**/*.coffee'],
+      app: ['scripts/*.coffee', 'test/*.coffee'],
       options: {
         'arrow_spacing': {'level': 'warn'},
         'braces_spacing': {'level': 'warn'},
+        'max_line_length': {'value': 120, 'level': 'warn'},
         'no_empty_functions': {'level': 'warn'},
         'no_empty_param_list': {'level': 'warn'},
         'no_interpolation_in_single_quotes': {'level': 'warn'},

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "grunt-release": "^0.13.0",
     "hubot-test-helper": "1.5.0",
     "istanbul": "0.4.5",
+    "mocha": "3.2.0",
     "sinon": "1.17.6"
   },
   "license": "MIT"

--- a/scripts/standup.coffee
+++ b/scripts/standup.coffee
@@ -102,10 +102,10 @@ module.exports = (robot) ->
        robot.adapter.client.rtm.dataStore and
        robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById
 
-      roomName = robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById room
+      roomObject = robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById room
 
-      if roomName
-        return roomName
+      if roomObject
+        return roomObject.name
 
     return room
 

--- a/scripts/standup.coffee
+++ b/scripts/standup.coffee
@@ -95,6 +95,20 @@ module.exports = (robot) ->
       room = msg.envelope.user.reply_to
     room
 
+  # Returns human-readable name of the room.
+  # Currently implemented for Slack adapter only.
+  getRoomName = (room) ->
+    if robot.adapter.client and robot.adapter.client.rtm and
+       robot.adapter.client.rtm.dataStore and
+       robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById
+
+      roomName = robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById room
+
+      if roomName
+        return roomName
+
+    return room
+
   # Confirm a time is in the valid 00:00 format
   timeIsValid = (time) ->
     validateTimePattern = /([01]?[0-9]|2[0-4]):[0-5][0-9]/
@@ -193,7 +207,7 @@ module.exports = (robot) ->
       msg.send 'No, because there aren\'t any.'
     else
       standupsText = [ 'Here\'s the standups for every room:' ].concat(_.map(standups, (standup) ->
-        text =  'Room: ' + standup.room + ', time: ' + standup.time
+        text =  'Room: ' + getRoomName(standup.room) + ', time: ' + standup.time
         if standup.timezone
           text += ' ' + standup.timezone
         else


### PR DESCRIPTION
Slack adapter switched to channel IDs instead of names, this uses a function provided by the adapter to translate the ID to the channel name for display.